### PR TITLE
Adding a writable getBoid() method.

### DIFF
--- a/src/Flock.cpp
+++ b/src/Flock.cpp
@@ -10,7 +10,14 @@ int Flock::getSize()
     return flock.size();
 }
 
+//Read only method that returns a copy of the Boid.
 Boid Flock::getBoid(int i)
+{
+    return flock[i];
+}
+
+//Read/write method that returns a reference of the Boid.
+Boid &Flock::getBoid(int i)
 {
     return flock[i];
 }

--- a/src/Flock.h
+++ b/src/Flock.h
@@ -19,7 +19,7 @@ public:
     int getSize();
     //Read only and read/write methods.
     Boid getBoid(int i);
-    Boid &getBid(int i);
+    Boid &getBoid(int i);
     // Mutator Functions
     void addBoid(const Boid& b);
     void flocking();

--- a/src/Flock.h
+++ b/src/Flock.h
@@ -13,15 +13,18 @@
 
 class Flock {
 public:
-    vector<Boid> flock;
     //Constructors
     Flock() {}
     // Accessor functions
     int getSize();
+    //Read only and read/write methods.
     Boid getBoid(int i);
+    Boid &getBid(int i);
     // Mutator Functions
     void addBoid(const Boid& b);
     void flocking();
+private:
+    vector<Boid> flock;  
 };
 
 #endif


### PR DESCRIPTION
These changes simply add a writable `getBoid()` method that will return a reference that can be changed elsewhere in the program. It also makes the vector flock private considering that this vector is only accessed through getters and setters anyways.